### PR TITLE
Allow API host to be overridden with an optional CLI param and use flags instead of positional args.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Quick setup
 
 1. Run the script, passing in the project key, source and destination environments, and API token:
 
-        node index.js PROJECT_KEY SOURCE_ENVIRONMENT_KEY DEST_ENVIRONMENT_KEY API_TOKEN
+        node index.js --project-key PROJECT_KEY --source-env SOURCE_ENVIRONMENT_KEY --destination-env DEST_ENVIRONMENT_KEY --api-token API_TOKEN
 
-   Optionally pass a host override as a fourth argument:
+   Optionally pass a host override:
 
-        node index.js PROJECT_KEY SOURCE_ENVIRONMENT_KEY DEST_ENVIRONMENT_KEY API_TOKEN https://your-launch-darkly-deploy.com
+        node index.js -p PROJECT_KEY -s SOURCE_ENVIRONMENT_KEY -d DEST_ENVIRONMENT_KEY -t API_TOKEN -H https://your-launch-darkly-deploy.com
 
 Note
 ----

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Quick setup
 
         node index.js PROJECT_KEY SOURCE_ENVIRONMENT_KEY DEST_ENVIRONMENT_KEY API_TOKEN
 
+   Optionally pass a host override as a fourth argument:
+
+        node index.js PROJECT_KEY SOURCE_ENVIRONMENT_KEY DEST_ENVIRONMENT_KEY API_TOKEN https://your-launch-darkly-deploy.com
+
 Note
 ----
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 'use strict';
 
+const DEFAULT_HOST = 'https://app.launchdarkly.com';
+
 var jsonpatch = require('fast-json-patch'),
   request = require('request'),
-  baseUrl = 'https://app.launchdarkly.com/api/v2',
   projectKey = '',
   sourceEnvironment = '',
   destinationEnvironment = '',
@@ -112,7 +113,9 @@ if (require.main === module) {
   var projectKey = process.argv[2],
       sourceEnvironment = process.argv[3],
       destinationEnvironment = process.argv[4],
-      apiToken = process.argv[5];
+      apiToken = process.argv[5],
+      hostUrl = process.argv[6] || DEFAULT_HOST,
+      baseUrl = hostUrl + '/api/v2';
 
   if (!projectKey) {
     throw new Error('Missing project key for sync');

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const DEFAULT_HOST = 'https://app.launchdarkly.com';
 
 var jsonpatch = require('fast-json-patch'),
   request = require('request'),
+  program = require('commander'),
   projectKey = '',
   sourceEnvironment = '',
   destinationEnvironment = '',
@@ -109,32 +110,50 @@ function syncEnvironment (fromKey, toKey) {
   });
 }
 
+program
+  .option('-p, --project-key <key>', 'Project key')
+  .option('-s, --source-env <key>', 'Source environment')
+  .option('-d, --destination-env <key>', 'Destination envrionment')
+  .option('-t, --api-token <token>', 'Api token')
+  .option('-H, --host <host>', 'Hostname override')
+  .parse(process.argv);
+
 if (require.main === module) {
-  var projectKey = process.argv[2],
-      sourceEnvironment = process.argv[3],
-      destinationEnvironment = process.argv[4],
-      apiToken = process.argv[5],
-      hostUrl = process.argv[6] || DEFAULT_HOST,
+  var projectKey = program.projectKey,
+      sourceEnvironment = program.sourceEnv,
+      destinationEnvironment = program.destinationEnv,
+      apiToken = program.apiToken,
+      hostUrl = program.host || DEFAULT_HOST,
       baseUrl = hostUrl + '/api/v2';
 
   if (!projectKey) {
-    throw new Error('Missing project key for sync');
+    console.error('Invalid usage: Please provide a value for --project-key');
+    program.outputHelp();
+    process.exit(1);
   }
 
   if (!sourceEnvironment) {
-    throw new Error('Missing source environment for sync');
+    console.error('Invalid usage: Please provide a value for --source-env');
+    program.outputHelp();
+    process.exit(1);
   }
 
   if (!destinationEnvironment) {
-    throw new Error('Missing destination environment for sync');
+    console.error('Invalid usage: Please provide a value for --destination-env');
+    program.outputHelp();
+    process.exit(1);
   }
 
   if (sourceEnvironment === destinationEnvironment) {
-    throw new Error('Why are you syncing the same environment?!');
+    console.error('Invalid usage: Why are you syncing the same environment?!');
+    program.outputHelp();
+    process.exit(1);
   }
 
   if (!apiToken) {
-    throw new Error('Missing api token for sync');
+    console.error('Invalid usage: Please provide a value for --api-token');
+    program.outputHelp();
+    process.exit(1);
   }
   
   syncEnvironment(sourceEnvironment, destinationEnvironment);

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "commander": "^2.17.1",
     "fast-json-patch": "^0.5.6",
     "request": "^2.72.0"
   },


### PR DESCRIPTION
This PR updates the script to check for a fourth command line parameter. If its present, use that as the API host, otherwise fall back on https://app.launchdarkly.com.

**Edit:** also converts positional args to flags.